### PR TITLE
Fix padding of key_area_key_application_10

### DIFF
--- a/switchfs/nca.go
+++ b/switchfs/nca.go
@@ -108,7 +108,7 @@ func decryptAesCtr(ncaHeader *ncaHeader, fsHeader *fsHeader, offset uint32, size
 
 	keys, _ := settings.SwitchKeys()
 
-	keyName := fmt.Sprintf("key_area_key_application_0%x", keyRevision)
+	keyName := fmt.Sprintf("key_area_key_application_%02x", keyRevision)
 	KeyString := keys.GetKey(keyName)
 	if KeyString == "" {
 		return nil, errors.New(fmt.Sprintf("missing Key_area_key[%v]", keyName))


### PR DESCRIPTION
Fixes the behavior where a zero is incorrectly prepended to a key value and results in switch-library-manager being unable to find the key in prod.keys.

Current, incorrect behavior: `key_area_key_application_010`
PR, Correct behavior: `key_area_key_application_10`

Fixes #104 